### PR TITLE
Introduce standardization docs and templates; update root README to Phase 1

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,38 +1,97 @@
 * Audit Tools
 
-*Audit Tools* is a collection of open-source Python scripts and related resources
-intended to support auditors, risk professionals, and data analysts in
-automating common audit procedures and analyses.
+*Audit Tools* is an open-source collection of scripts, SQL queries, and supporting
+resources for audit evidence collection and analysis.
 
-This repository includes practical examples that can be used as-is or adapted to
-specific audit environments.
+The repository is designed for:
+- auditors and risk professionals who need practical evidence gathering tools,
+- analysts who need reproducible output artifacts,
+- contributors who want to add or improve control-focused automation.
 
-** Contents
+This repository currently contains working tools with mixed styles. The ongoing
+standardization effort introduces shared documentation, templates, and output
+models without breaking existing scripts.
 
-| Directory            | Description                                                                  |
-|----------------------+------------------------------------------------------------------------------|
-| =applications/aws/=    | AWS IAM users, password policy, and S3 bucket analysis                       |
-| =applications/github/= | GitHub admin enumeration, audit log, branch protections, and commit analysis |
-| =applications/gitlab/= | GitLab user provisioning, branch protections, approvals, pipelines, and more |
-| =databases/mongo/=     | MongoDB admin enumeration                                                    |
-| =databases/mysql/=     | MySQL admin and password queries                                             |
-| =databases/oracle/=    | Oracle admin queries                                                         |
-| =databases/postgres/=  | PostgreSQL admin and password queries                                        |
-| =databases/sql/=       | Generic SQL admin queries and password analysis                              |
-| =os/linux/=            | Linux OS reporting, password file analysis, and SSH root login checks        |
-| =project_management/=  | Audit project tracking dashboards (Alteryx, Dash, Power BI)                  |
-| =sampling/=            | Random and stratified sampling tools                                         |
+** Repository Areas
+
+| Directory              | Purpose                                                                       |
+|------------------------+-------------------------------------------------------------------------------|
+| =applications/=          | Platform/application evidence scripts (AWS, GitHub, GitLab)                  |
+| =databases/=             | SQL and database evidence queries/scripts                                     |
+| =os/=                    | Operating system evidence scripts                                             |
+| =sampling/=              | Sampling utilities for audit procedures                                       |
+| =project_management/=    | Project support artifacts (dashboards/workbooks)                              |
+| =docs/=                  | Standardization and migration planning documentation                           |
+| =templates/=             | Reusable templates for future tools, metadata, and documentation               |
+
+** Current Purpose and Phase
+
+Current phase: *Standardization Phase 1 (documentation and templates only)*.
+
+What this means:
+- Existing scripts remain usable as-is.
+- New platform scripts are not being added in this phase.
+- Shared standards are being documented to support safer, more consistent
+  follow-up implementation commits.
+
+** Standardized Tool Expectations (Target Model)
+
+Future and migrated tools should:
+- be easy to run independently,
+- preserve raw evidence,
+- produce normalized parsed outputs,
+- separate exceptions from standard results,
+- write run metadata (scope, command, timestamp, tool version),
+- fail safely with clear error reporting,
+- avoid destructive actions,
+- avoid logging or writing credentials.
+
+See detailed standards:
+- =docs/standards-index.md=
+- =docs/script-standards.md=
+- =docs/output-standards.md=
+- =docs/documentation-standards.md=
+
+** Standard Output Model
+
+Target output model for each tool run:
+
+#+begin_src text
+outputs/
+  <tool_name>/
+    <run_id>/
+      raw/
+      parsed/
+      exceptions/
+      evidence/
+      logs/
+      metadata.json
+#+end_src
+
+For an example with sample files, see:
+- =templates/output-tree-example.md=
+- =templates/metadata-template.json=
+
+** Auditor-Focused Usage Guidance
+
+When using any tool in this repository:
+1. Confirm scope first (organization/account/project/host/database).
+2. Capture run command and timestamp in workpapers.
+3. Preserve raw evidence outputs for re-performance.
+4. Document known limitations and uncollected areas.
+5. Validate whether credentials are sourced securely (env/profile/config).
+
+If a script currently prints output only to terminal, save output in your
+workpapers and document the command used.
 
 ** Getting Started
 
 *Clone the Repository*
 
 #+begin_src bash
-git clone https://github.com/audit-lab/audit-toolss
+git clone https://github.com/audit-lab/audit-tools
 cd audit-tools
 #+end_src
-
-#+RESULTS:
 
 *Install Dependencies*
 
@@ -40,45 +99,40 @@ cd audit-tools
 pip install -r requirements.txt
 #+end_src
 
-*Run a Script*
+*Run an Existing Script*
 
-For example, to run the Linux OS report tool:
+Example shell script:
 
 #+begin_src bash
 ./os/linux/report/linux.sh
 #+end_src
 
-Or to run a Python script:
+Example Python script:
 
 #+begin_src bash
 python sampling/sample.py
 #+end_src
 
-Output will be shown in the terminal or saved to a file, depending on the
-script.
+Note: output behavior currently varies by script. Use script-specific README
+files and preserve outputs in audit workpapers.
+
+** Documentation Reading Order
+
+Start with:
+1. =docs/standards-index.md=
+2. =docs/standardization-plan.md=
+3. =docs/repository-structure.md=
+4. =docs/script-standards.md=
+5. =docs/output-standards.md=
+6. =docs/documentation-standards.md=
+7. =docs/migration-plan.md=
 
 ** Contributing
 
-Contributions are welcome. You can contribute by:
+Contributions are welcome, especially:
+- improvements to evidence defensibility,
+- better input validation and safe error handling,
+- documentation clarity for non-engineering auditors,
+- tests and linting support.
 
-- Adding new audit-related scripts
-- Suggesting improvements or feature ideas
-- Enhancing documentation
-- Testing the tools on additional datasets and reporting any issues
-
-To contribute:
-
-1. Fork the repository
-2. Create a new branch:
-   #+begin_src bash
-   git checkout -b my-feature
-   #+end_src
-3. Commit your changes:
-   #+begin_src bash
-   git commit -m 'Added new audit test'
-   #+end_src
-4. Push your branch:
-   #+begin_src bash
-   git push origin my-feature
-   #+end_src
-5. Open a pull request
+Please follow the documented standards and templates before adding new scripts.

--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ models without breaking existing scripts.
 
 ** Current Purpose and Phase
 
-Current phase: *Standardization Phase 1 (documentation and templates only)*.
+Current phase: *Standardization Phase 0 (documentation and templates only)*.
 
 What this means:
 - Existing scripts remain usable as-is.

--- a/docs/documentation-standards.md
+++ b/docs/documentation-standards.md
@@ -1,0 +1,41 @@
+# Documentation Standards
+
+## Root README standard
+Create/maintain a canonical `README.md` with:
+1. Purpose and intended audit use cases.
+2. Repository map by domain.
+3. Quick-start (dependencies, auth setup, first run).
+4. Safety/security notice (read-only, no secrets in outputs).
+5. Output model summary.
+6. Contribution workflow and coding standards links.
+
+## Per-tool README structure
+Each tool directory should include `README.md` with:
+1. **Audit purpose** (control objective and why it matters).
+2. **Evidence produced** (raw, parsed, exceptions).
+3. **Prerequisites** (permissions, APIs, binaries).
+4. **Inputs and scope** (required identifiers, time bounds).
+5. **Usage examples** (minimal + advanced).
+6. **Output schema** (columns/fields and definitions).
+7. **Known limitations** (API tier limits, blind spots).
+8. **Validation/reperformance steps**.
+
+## Sample output documentation
+- Provide small sanitized samples under a `samples/` subfolder per tool.
+- Include `samples/README.md` mapping sample files to schemas.
+- Keep samples deterministic and non-sensitive.
+
+## Documentation style conventions
+- Prefer plain, auditor-friendly language over implementation jargon.
+- Explicitly call out what was **not** collected and why.
+- Include date/time format and timezone assumptions (UTC by default).
+- Document expected error scenarios and remediation.
+
+## Control-area mapping guidance
+For each tool README, include a mini table:
+- `control_area`
+- `risk_addressed`
+- `evidence_type`
+- `primary_output_file`
+
+This keeps tools aligned with audit objectives rather than only technical output.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,0 +1,65 @@
+# Phased Migration Plan
+
+## Current-state inconsistencies to address first
+1. Hardcoded credentials/tokens in scripts (notably GitLab scripts).
+2. Non-standard output paths and file naming.
+3. Mixed CLI conventions and lack of config validation.
+4. Inconsistent docs depth and format.
+5. Missing tests and lint/format enforcement.
+
+## Proposed phases
+
+### Phase 0 — Baseline and guardrails
+- Add standards docs (this commit).
+- Add `.gitignore` rules for `outputs/` and temporary files.
+- Add minimal CI checks for lint/test placeholders.
+
+### Phase 1 — Shared runtime foundation
+- Introduce shared utility module (Python) for:
+  - argument patterns,
+  - output path creation,
+  - metadata writer,
+  - logging helper,
+  - safe error/reporting patterns.
+- Add shell helper snippets for standardized folder creation and metadata stubs.
+
+### Phase 2 — Highest-risk script remediation
+- Migrate scripts with hardcoded secrets first (GitLab).
+- Standardize auth input through env/config.
+- Ensure no credentials appear in output/logs.
+
+### Phase 3 — Output normalization
+- Update GitHub, AWS, Linux scripts to emit standard folder structure.
+- Preserve existing files where possible, but route them into `raw/`, `parsed/`, `exceptions/`, `evidence/`, `logs/`.
+- Add `metadata.json` to every tool run.
+
+### Phase 4 — Documentation normalization
+- Convert root `README.org` to `README.md` (or maintain both temporarily with one canonical source).
+- Add per-tool README sections per standard template.
+- Add sample outputs and schema notes.
+
+### Phase 5 — Testing and quality gates
+- Add unit tests for parsers/normalizers.
+- Add smoke tests for CLI invocation (`--dry-run`).
+- Add lint/format tooling and CI gate.
+
+## Risks and tradeoffs
+- **Risk**: Over-standardization slows contributor adoption.
+  - **Mitigation**: keep mandatory core small; provide templates.
+- **Risk**: Shell and Python parity is hard.
+  - **Mitigation**: standardize outputs/metadata first, internals second.
+- **Risk**: Existing users depend on old output file paths.
+  - **Mitigation**: transition period with compatibility symlinks or duplicate writes.
+
+## Open questions for implementation pass
+1. Should Python become the default for new tools, with shell only for platform-native commands?
+2. Is `pyproject.toml` acceptable as primary dependency source while retaining `requirements.txt` export?
+3. Which scripts are considered authoritative for each control area where duplicates exist?
+4. What minimum supported Python version should be declared?
+
+## Specific files likely needing changes early
+- `applications/gitlab/*.py` (credential handling + CLI + structured output).
+- `applications/aws/*.sh` and `applications/aws/aws_password_policy/*` (output normalization + metadata).
+- `applications/github/audit.py` and reporters (new output tree + metadata schema).
+- `os/linux/*.sh` (sudo behavior documentation, standardized output + logging).
+- `README.org` and all per-tool README files (template alignment).

--- a/docs/output-standards.md
+++ b/docs/output-standards.md
@@ -1,0 +1,90 @@
+# Output, Schema, Metadata, and Evidence Standards
+
+## Standard output directory model
+
+```text
+outputs/
+  <tool_name>/
+    <run_id>/
+      raw/
+      parsed/
+      exceptions/
+      evidence/
+      logs/
+      metadata.json
+```
+
+## Run ID standard
+- Format: `<tool_name>_<target_scope>_<YYYYMMDDTHHMMSSZ>`
+- Example: `github_org_audit_acme_20260429T141530Z`
+- Must be deterministic per run invocation timestamp.
+
+## Folder intent
+- `raw/`: unmodified API responses, command output, source extracts.
+- `parsed/`: normalized CSV/JSON for analysis.
+- `exceptions/`: records that need manual follow-up (missing fields, API denials, parse failures).
+- `evidence/`: auditor-facing summary artifacts (tables, narrative notes, screenshots if relevant).
+- `logs/`: operational logs.
+
+## CSV/JSON schema conventions
+- Use lowercase `snake_case` column keys.
+- Include stable unique keys where possible (`record_id`, `source_id`).
+- Add `source_system`, `collected_at`, and `tool_name` for traceability in parsed outputs.
+- Nulls should be explicit (`""` in CSV, `null` in JSON).
+
+## Evidence metadata schema (`metadata.json`)
+
+Required fields:
+- `tool_name`
+- `tool_version`
+- `run_id`
+- `run_started_at`
+- `run_completed_at`
+- `system_type`
+- `target_scope`
+- `command`
+- `user_context`
+- `hostname`
+- `source_files`
+- `output_files`
+- `record_counts`
+- `warnings`
+- `errors`
+- `credential_fields_redacted`
+- `schema_version`
+
+Recommended fields:
+- `git_commit`
+- `script_path`
+- `dependencies`
+- `api_rate_limit_observed`
+
+## Example metadata.json
+```json
+{
+  "tool_name": "github_org_audit",
+  "tool_version": "0.2.0",
+  "run_id": "github_org_audit_acme_20260429T141530Z",
+  "run_started_at": "2026-04-29T14:15:30Z",
+  "run_completed_at": "2026-04-29T14:17:05Z",
+  "system_type": "github",
+  "target_scope": "org:acme",
+  "command": "python main.py --scope acme --output-dir ./outputs",
+  "user_context": "local_user",
+  "hostname": "audit-host-01",
+  "source_files": ["raw/repos_page_1.json"],
+  "output_files": ["parsed/member_roster.csv"],
+  "record_counts": {"member_roster": 254},
+  "warnings": [],
+  "errors": [],
+  "credential_fields_redacted": ["authorization_header"],
+  "schema_version": "1.0.0"
+}
+```
+
+## Audit defensibility requirements
+- Preserve raw evidence to permit re-performance.
+- Keep parsed outputs reproducible from raw inputs.
+- Track command and scope exactly.
+- Separate exceptions from compliant/normal records.
+- Never overwrite prior runs; each run gets its own folder.

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -1,0 +1,85 @@
+# Repository Structure Assessment and Target Model
+
+## Current structure (as of 2026-04-29)
+
+```text
+.
+├── applications/
+│   ├── aws/
+│   ├── github/
+│   └── gitlab/
+├── databases/
+│   ├── mongo/
+│   ├── mysql/
+│   ├── oracle/
+│   ├── postgres/
+│   └── sql/
+├── os/
+│   ├── linux/
+│   └── windows/
+├── project_management/
+├── sampling/
+├── README.org
+└── requirements.txt
+```
+
+### Observed categories
+- **Platform/API scripts**: `applications/*` (AWS, GitHub, GitLab).
+- **Database evidence queries/scripts**: `databases/*` (mixed SQL and Python).
+- **Host/OS evidence scripts**: `os/linux/*`.
+- **Sampling utilities**: `sampling/*`.
+- **Non-collection artifacts**: `project_management/*` (dashboards/workbooks).
+
+## Key structural inconsistencies
+1. **Mixed script placement patterns**: some tools have subpackages (`applications/github/collectors`), others are flat files.
+2. **No cross-repo standard output root**: scripts write to `./output`, current directory, or terminal only.
+3. **No common `docs/` model** for per-tool audit purpose, control mapping, or schema.
+4. **Mixed README formats**: root uses `README.org`, most subareas use markdown.
+5. **No `tests/` structure** for any script family.
+
+## Proposed target repository layout
+
+```text
+.
+├── tools/
+│   ├── applications/
+│   │   ├── aws/
+│   │   │   ├── iam_assignments/
+│   │   │   ├── password_policy/
+│   │   │   └── s3_public_access/
+│   │   ├── github/
+│   │   │   └── org_audit/
+│   │   └── gitlab/
+│   │       ├── approvals/
+│   │       ├── branch_protections/
+│   │       └── ...
+│   ├── databases/
+│   ├── os/
+│   └── sampling/
+├── docs/
+│   ├── repository-structure.md
+│   ├── script-standards.md
+│   ├── output-standards.md
+│   ├── documentation-standards.md
+│   ├── migration-plan.md
+│   └── standardization-plan.md
+├── outputs/                      # gitignored runtime evidence root
+├── tests/
+│   ├── unit/
+│   ├── integration/
+│   └── fixtures/
+├── pyproject.toml                # Python dependency + lint config
+├── requirements.txt              # optional lock/export for compatibility
+└── README.md
+```
+
+## Practical adoption notes (non-breaking)
+- Keep existing folders temporarily; add `tools/` gradually and migrate scripts in phases.
+- If immediate relocation is too disruptive, keep current paths but enforce standards first.
+- Standardize script behavior/output before moving every file.
+
+## Files likely needing future structural changes
+- Root documentation: `README.org` → future canonical `README.md`.
+- Flat GitLab scripts under `applications/gitlab/*.py` into per-tool directories.
+- Shell scripts writing local reports (`applications/aws/*.sh`, `os/linux/*.sh`) to standard `outputs/<tool>/<run_id>/...`.
+- Add missing top-level `tests/`, `outputs/.gitkeep`, and `.gitignore` rules.

--- a/docs/script-standards.md
+++ b/docs/script-standards.md
@@ -1,0 +1,72 @@
+# Script Standards
+
+## Scope
+Applies to all future tools and all migrated existing tools in `applications/`, `databases/`, `os/`, and `sampling/`.
+
+## Naming conventions
+- Script/tool folder: `snake_case` control-focused name (`branch_protections`, `iam_assignments`).
+- Main executable:
+  - Python: `main.py` (or package entrypoint).
+  - Shell: `run.sh` only when shell is justified.
+- Output dataset files: `snake_case` nouns (`members.csv`, `exceptions.json`).
+
+## CLI argument conventions (required defaults)
+Every runnable tool should support:
+- `--output-dir` (default: `./outputs`)
+- `--format` (`csv`, `json`, or both where applicable)
+- `--dry-run` (where collection side effects are possible)
+- `--verbose`
+- `--quiet`
+- `--config <path>` (where useful)
+
+Recommended additions:
+- `--scope` (org/account/project/db target)
+- `--since` / `--until` for date-bounded evidence pulls
+- `--timeout`
+
+## Input handling conventions
+- Validate required scope inputs at startup.
+- Validate mutually exclusive options.
+- Validate date formats (`YYYY-MM-DD`) and IDs before calls.
+- Reject unknown config keys with clear messages.
+- Print concise usage on argument failure; exit code `2`.
+
+## Authentication / credential handling
+- Credentials must come from environment variables, profile chains, or external secret manager references.
+- Never hardcode tokens/keys (current GitLab scripts do this; must be removed).
+- Never echo raw credentials in stdout, logs, metadata, or output files.
+- Log only credential source type (e.g., `auth_source: env:GITHUB_TOKEN`).
+
+## Logging conventions
+- Dual-mode logging:
+  - Human-readable console summary.
+  - Structured run log at `logs/run.log` (timestamp + level + event).
+- Levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`.
+- Start and end of each collection step must be logged.
+
+## Error handling conventions
+- Fail safely (no destructive actions).
+- Continue non-dependent collectors when one collector fails.
+- Record step-level errors in `exceptions/` and `metadata.json`.
+- Return non-zero if any required collection failed.
+- Standard exit codes:
+  - `0`: success (possibly with warnings)
+  - `1`: collection failure
+  - `2`: invalid arguments/config
+  - `3`: authentication failure
+
+## Script template (recommended)
+1. Parse args.
+2. Resolve config + credentials.
+3. Build deterministic `run_id` and output paths.
+4. Validate scope and prerequisites.
+5. Collect raw evidence.
+6. Normalize parsed outputs.
+7. Emit exceptions and metadata.
+8. Print summary + proper exit code.
+
+## Security constraints
+- Read-only behavior unless explicitly documented and opt-in.
+- Minimum API permissions documented per tool.
+- Redact identity fields only when legally required; otherwise preserve audit traceability.
+- Protect PII/secret-bearing outputs through clear warnings and optional masking flags.

--- a/docs/standardization-plan.md
+++ b/docs/standardization-plan.md
@@ -1,0 +1,93 @@
+# Audit-Tools Standardization Plan (Pre-Implementation)
+
+## Purpose
+This plan establishes a practical, auditor-friendly standard for future development in this repository before adding new platform scripts.
+
+## Assessment summary of current repository
+
+### Structure and usage patterns
+- Repository is organized by domain (`applications`, `databases`, `os`, `sampling`) but implementation style is highly mixed.
+- Some tools are packaged and orchestrated (GitHub audit), while others are single-file ad hoc scripts.
+- Output behavior varies: terminal-only, local flat files, custom timestamp folders, or no persisted evidence.
+
+### Dependencies and runtime
+- Global dependencies are minimal (`pandas`, `requests`, `dash`, `plotly`) and not tied to per-tool requirements.
+- Several shell tools require external binaries (`aws`, `jq`, `netstat`, distro-specific commands) but these are inconsistently documented.
+
+### Naming and documentation patterns
+- Script names are mostly descriptive but not consistently scoped by control objective.
+- README depth varies significantly by domain.
+- Root README contains a typo in clone URL and is Org format, while subdocs are mostly Markdown.
+
+### Authentication handling
+- GitHub uses env/config pattern (good baseline).
+- Multiple GitLab scripts hardcode token placeholders in source (must be remediated before extension).
+- AWS scripts rely on ambient CLI auth (acceptable if explicitly documented).
+
+### Output/evidence consistency
+- GitHub has strongest structure (timestamped output folder + summary).
+- AWS/Linux scripts generate varying flat report files and mixed JSON/text.
+- No common metadata manifest across tools.
+- No standard separation of raw evidence vs parsed evidence vs exceptions.
+
+## Inconsistencies identified
+1. CLI argument sets differ (or are absent).
+2. Output roots and naming are inconsistent.
+3. Data schemas vary without documented contracts.
+4. Error handling ranges from silent fallback to immediate exit without normalized exception records.
+5. Authentication practices are inconsistent and sometimes insecure.
+6. No unified test or lint strategy.
+
+## Target standards (authoritative references)
+- Repository structure: `docs/repository-structure.md`
+- Script behavior + CLI + error/logging: `docs/script-standards.md`
+- Output/model/schema + metadata: `docs/output-standards.md`
+- Root/per-tool documentation templates: `docs/documentation-standards.md`
+- Delivery sequence and risks: `docs/migration-plan.md`
+
+## Proposed standard script template (minimal)
+1. Parse standard args.
+2. Validate scope, auth, and prerequisites.
+3. Create deterministic run directory.
+4. Collect raw data (non-destructive).
+5. Transform to parsed normalized datasets.
+6. Write exceptions and metadata.
+7. Write logs and concise auditor summary.
+8. Return standard exit code.
+
+## Before/after examples
+
+### Example A: GitLab flat script
+- **Before**: token in code, prints to terminal, no output package.
+- **After**: env/config auth, writes standard output tree, includes `metadata.json`, parsed CSV/JSON, and exception records.
+
+### Example B: Linux shell report
+- **Before**: single `report.txt`, mixed command/file output.
+- **After**: raw command captures in `raw/`, normalized checks in `parsed/`, failed commands in `exceptions/`, plus run log and metadata.
+
+## Dependency and quality strategy
+- Short term: retain `requirements.txt` for compatibility.
+- Medium term: introduce `pyproject.toml` for tooling and consistent dev setup.
+- Add lint/format baselines (`ruff` + `black` for Python, `shellcheck` + `shfmt` for shell).
+- Add minimal test harness with smoke tests for all CLI entrypoints.
+
+## Security and defensibility guidance
+- Never write credentials to outputs/logs.
+- Minimize privileges and document required scopes.
+- Keep raw evidence immutable per run.
+- Ensure chain of custody via metadata (`who`, `when`, `scope`, `command`, `tool version`).
+- Log what was not collected and why.
+
+## Phased execution plan (for follow-up commits)
+- Execute phases exactly as documented in `docs/migration-plan.md`.
+- Prioritize credential-remediation and output normalization before adding new scripts.
+
+## Concise checklist for next implementation pass
+- [ ] Add shared CLI/output/metadata utilities.
+- [ ] Migrate GitLab scripts off hardcoded credential patterns.
+- [ ] Implement standard output tree for GitHub/AWS/Linux tools.
+- [ ] Add `metadata.json` emission to every run.
+- [ ] Normalize README structure at root and per-tool levels.
+- [ ] Add tests (CLI smoke + parser unit tests).
+- [ ] Add lint/format tooling and CI enforcement.
+- [ ] Preserve backward compatibility notes for legacy output paths.

--- a/docs/standards-index.md
+++ b/docs/standards-index.md
@@ -1,0 +1,23 @@
+# Standards Index
+
+Use this index to read the standardization guidance in order.
+
+1. **Standardization plan (overview):** `docs/standardization-plan.md`
+   - What was assessed, why standardization is needed, and the implementation checklist.
+2. **Repository structure:** `docs/repository-structure.md`
+   - Current layout, inconsistencies, and target structure.
+3. **Script standards:** `docs/script-standards.md`
+   - Naming, CLI behavior, input/auth handling, logging, and error conventions.
+4. **Output standards:** `docs/output-standards.md`
+   - Standard output tree, schema conventions, and metadata requirements.
+5. **Documentation standards:** `docs/documentation-standards.md`
+   - Root/per-tool README expectations and sample documentation approach.
+6. **Migration plan:** `docs/migration-plan.md`
+   - Phased implementation sequence, risks, tradeoffs, and open questions.
+
+## Template references for implementation
+- `templates/tool-readme-template.md`
+- `templates/script-header-template.py`
+- `templates/script-header-template.sh`
+- `templates/metadata-template.json`
+- `templates/output-tree-example.md`

--- a/templates/metadata-template.json
+++ b/templates/metadata-template.json
@@ -1,0 +1,19 @@
+{
+  "tool_name": "<tool_name>",
+  "tool_version": "0.1.0",
+  "run_id": "<tool_name>_<scope>_<YYYYMMDDTHHMMSSZ>",
+  "run_started_at": "<ISO8601_UTC>",
+  "run_completed_at": "<ISO8601_UTC>",
+  "system_type": "<system_type>",
+  "target_scope": "<scope_expression>",
+  "command": "<exact_command_used>",
+  "user_context": "<local_user_or_service_identity>",
+  "hostname": "<host>",
+  "source_files": [],
+  "output_files": [],
+  "record_counts": {},
+  "warnings": [],
+  "errors": [],
+  "credential_fields_redacted": [],
+  "schema_version": "1.0.0"
+}

--- a/templates/output-tree-example.md
+++ b/templates/output-tree-example.md
@@ -1,0 +1,30 @@
+# Output Tree Example
+
+Use this output structure for each tool run.
+
+```text
+outputs/
+  github_org_audit/
+    github_org_audit_acme_20260429T141530Z/
+      raw/
+        repos_page_1.json
+        repos_page_2.json
+      parsed/
+        member_roster.csv
+        branch_protections.csv
+      exceptions/
+        api_denials.json
+      evidence/
+        summary.md
+      logs/
+        run.log
+      metadata.json
+```
+
+## Practical Notes
+- `raw/` should contain unmodified source evidence.
+- `parsed/` should contain normalized analysis-ready outputs.
+- `exceptions/` should contain incomplete, denied, or failed records.
+- `evidence/` should contain auditor-readable summaries.
+- `logs/` should contain operational run logs only (no secrets).
+- `metadata.json` should document run scope, command, timestamps, and counts.

--- a/templates/script-header-template.py
+++ b/templates/script-header-template.py
@@ -1,0 +1,25 @@
+"""
+<Tool Name>
+
+Audit purpose:
+    <Short control-focused description>
+
+Safety:
+    - Read-only collection behavior
+    - No credential logging
+
+Usage examples:
+    python main.py --scope <target> --output-dir ./outputs
+    python main.py --scope <target> --output-dir ./outputs --format csv --verbose
+
+Standard behavior:
+    - Validates required inputs before collection
+    - Writes deterministic run artifacts under outputs/<tool_name>/<run_id>/
+    - Preserves raw evidence and writes normalized parsed outputs
+    - Records metadata.json and logs
+"""
+
+# NOTE:
+# - Load credentials from environment/config only.
+# - Do not hardcode tokens, keys, or passwords.
+# - Do not print secrets in stdout/stderr/log files.

--- a/templates/script-header-template.sh
+++ b/templates/script-header-template.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# <Tool Name>
+#
+# Audit purpose:
+#   <Short control-focused description>
+#
+# Safety:
+#   - Read-only collection behavior
+#   - No credential logging
+#
+# Usage examples:
+#   ./run.sh --scope <target> --output-dir ./outputs
+#   ./run.sh --scope <target> --output-dir ./outputs --format json --verbose
+#
+# Standard behavior:
+#   - Validate required inputs before collection
+#   - Write deterministic run artifacts under outputs/<tool_name>/<run_id>/
+#   - Preserve raw evidence and write normalized parsed outputs
+#   - Record metadata.json and logs
+#
+# NOTE:
+# - Load credentials from environment/config only.
+# - Never hardcode tokens, keys, or passwords.
+# - Never print secrets in stdout/stderr/log files.

--- a/templates/tool-readme-template.md
+++ b/templates/tool-readme-template.md
@@ -1,0 +1,61 @@
+# <Tool Name>
+
+## Audit Purpose
+Describe the control objective, risk addressed, and why this evidence matters in an audit.
+
+## What This Tool Collects
+- **Raw evidence:**
+- **Parsed evidence:**
+- **Exception evidence:**
+
+## Prerequisites
+- Access/role requirements:
+- API permissions/scopes:
+- Local dependencies:
+
+## Inputs and Scope
+- Required scope input(s):
+- Optional date range:
+- Assumptions/limitations:
+
+## Usage
+```bash
+# Basic run
+python main.py --scope <target> --output-dir ./outputs
+
+# Example with JSON output and verbose logs
+python main.py --scope <target> --output-dir ./outputs --format json --verbose
+```
+
+## Standard Output Model
+```text
+outputs/
+  <tool_name>/
+    <run_id>/
+      raw/
+      parsed/
+      exceptions/
+      evidence/
+      logs/
+      metadata.json
+```
+
+## Parsed Output Schema
+| Field | Type | Description |
+|---|---|---|
+| <field_name> | <string/int/bool> | <what it means> |
+
+## Evidence Defensibility Notes
+- State what was not collected and why.
+- Preserve raw source data for re-performance.
+- Document filters/scope in metadata.
+
+## Known Limitations
+- API tier gaps:
+- Data blind spots:
+- Runtime caveats:
+
+## Validation / Reperformance
+- Re-run command used:
+- Expected artifacts:
+- Manual verification steps:


### PR DESCRIPTION
### Motivation
- Create a documented standardization baseline to reduce inconsistent outputs, credential handling, and README formats across tools.
- Define a non-breaking Phase 1 (documentation and templates only) to prepare safer, consistent future migrations and remediation. 
- Provide a shared target output model and metadata schema to improve audit defensibility and reproducibility. 

### Description
- Rewrite root `README.org` to describe the repository purpose, current phase (`Standardization Phase 1`), target output model, usage guidance, and fix the clone URL to `git clone https://github.com/audit-lab/audit-tools` while preserving examples using `./os/linux/report/linux.sh` and `python sampling/sample.py`.
- Add core standardization documents under `docs/`: `standardization-plan.md`, `repository-structure.md`, `script-standards.md`, `output-standards.md`, `documentation-standards.md`, `migration-plan.md`, and `standards-index.md` that specify CLI conventions, output tree, metadata schema, phased migration, and priorities.
- Add reusable templates under `templates/`: `metadata-template.json`, `output-tree-example.md`, `tool-readme-template.md`, `script-header-template.py`, and `script-header-template.sh` to accelerate consistent tool authoring and documentation. 
- Clarify contributions guidance to emphasize evidence defensibility, input validation, and following the new standards; no runtime tool code was modified in this change. 

### Testing
- No automated tests were added or executed as part of this documentation-and-template-only change. 
- Migration plan and docs include steps to add CI checks, linting, and test harnesses in follow-up commits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2438291e08320a6d2b772f02f64e8)