### PR TITLE
feat: add shared execution and evidence framework

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,13 +26,13 @@ models without breaking existing scripts.
 
 ** Current Purpose and Phase
 
-Current phase: *Standardization Phase 0 (documentation and templates only)*.
+Current phase: *Standardization Phase 2 (shared framework scaffolding)*.
 
 What this means:
 - Existing scripts remain usable as-is.
 - New platform scripts are not being added in this phase.
-- Shared standards are being documented to support safer, more consistent
-  follow-up implementation commits.
+- Shared standards now include reusable shared Python/shell helpers and schema
+  contracts to support safer, more consistent implementation commits.
 
 ** Standardized Tool Expectations (Target Model)
 
@@ -71,6 +71,12 @@ outputs/
 For an example with sample files, see:
 - =templates/output-tree-example.md=
 - =templates/metadata-template.json=
+
+Shared framework references:
+- =shared/README.md=
+- =shared/python/=
+- =shared/shell/common.sh=
+- =shared/schemas/=
 
 ** Auditor-Focused Usage Guidance
 

--- a/docs/standards-index.md
+++ b/docs/standards-index.md
@@ -21,3 +21,11 @@ Use this index to read the standardization guidance in order.
 - `templates/script-header-template.sh`
 - `templates/metadata-template.json`
 - `templates/output-tree-example.md`
+
+
+## Shared framework implementation layer (Phase 2)
+- `shared/README.md`
+- `shared/python/`
+- `shared/shell/common.sh`
+- `shared/schemas/`
+- `shared/examples/`

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,35 @@
+# Shared Standardization Framework
+
+This folder provides lightweight, reusable components for Phase 2 of repository standardization.
+
+## Purpose
+
+The shared framework gives future scripts a common baseline for:
+- standard CLI flags and execution controls,
+- consistent logging behavior,
+- deterministic output directory layout,
+- standardized metadata and exceptions,
+- reusable JSON schema contracts.
+
+This is intentionally minimal and script-first. It is not a heavyweight internal platform.
+
+## Directory layout
+
+- `python/`: reusable Python helpers (`cli.py`, `logging.py`, `outputs.py`, `metadata.py`, `errors.py`)
+- `shell/common.sh`: reusable shell helpers and exit codes
+- `schemas/`: JSON schema references for metadata, evidence, and exceptions
+- `examples/`: sample output tree and sample JSON artifacts
+
+## How future scripts should use this
+
+1. Parse common CLI flags from `shared/python/cli.py` (or equivalent shell defaults).
+2. Initialize logging via `shared/python/logging.py` or `shared/shell/common.sh`.
+3. Create run directories with `shared/python/outputs.py` or `ensure_run_tree` in shell.
+4. Write metadata using `shared/python/metadata.py` or `write_metadata` in shell.
+5. Emit standardized exceptions using the shared exit code and schema model.
+
+## Legacy migration expectations
+
+- Existing scripts are not force-migrated in this phase.
+- Backward compatibility should be preserved as scripts adopt shared helpers.
+- Migration should happen incrementally by tool family, with behavior parity checks.

--- a/shared/examples/sample_exceptions.json
+++ b/shared/examples/sample_exceptions.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "DependencyError",
+    "message": "aws CLI not found",
+    "severity": "error",
+    "context": {"binary": "aws"}
+  }
+]

--- a/shared/examples/sample_metadata.json
+++ b/shared/examples/sample_metadata.json
@@ -1,0 +1,10 @@
+{
+  "tool": "applications-github-audit",
+  "run_id": "20260429T120000Z",
+  "timestamp_utc": "2026-04-29T12:00:00Z",
+  "command": "python applications/github/audit.py --output-dir outputs",
+  "scope": {"organization": "example-org"},
+  "record_counts": {"members": 25, "repos": 42},
+  "warnings": [],
+  "errors": []
+}

--- a/shared/examples/sample_output_tree/README.md
+++ b/shared/examples/sample_output_tree/README.md
@@ -1,0 +1,9 @@
+# Sample Output Tree
+
+This directory demonstrates the expected run structure.
+
+- `raw/`: direct command/API responses
+- `parsed/`: normalized outputs
+- `exceptions/`: standardized exception records
+- `evidence/`: retained source artifacts
+- `logs/`: script execution logs

--- a/shared/examples/sample_parsed_output.json
+++ b/shared/examples/sample_parsed_output.json
@@ -1,0 +1,4 @@
+[
+  {"control": "user_mfa_enabled", "subject": "alice", "status": "pass"},
+  {"control": "user_mfa_enabled", "subject": "bob", "status": "fail"}
+]

--- a/shared/python/cli.py
+++ b/shared/python/cli.py
@@ -1,0 +1,23 @@
+"""Shared argparse helpers and standard flags."""
+
+from __future__ import annotations
+
+import argparse
+
+
+DEFAULT_FORMATS = ("json", "csv", "txt")
+
+
+def add_standard_flags(parser: argparse.ArgumentParser, *, formats: tuple[str, ...] = DEFAULT_FORMATS) -> argparse.ArgumentParser:
+    """Attach standard execution flags to a parser."""
+    parser.add_argument("--output-dir", default="outputs", help="Root directory where run artifacts are written.")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug output.")
+    parser.add_argument("--quiet", action="store_true", help="Suppress non-error output.")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would run without collecting evidence.")
+    parser.add_argument("--format", choices=formats, default=formats[0], help="Primary parsed output format.")
+    return parser
+
+
+def build_parser(description: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=description)
+    return add_standard_flags(parser)

--- a/shared/python/errors.py
+++ b/shared/python/errors.py
@@ -1,0 +1,57 @@
+"""Shared exceptions and exit codes for audit scripts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class ExitCodes:
+    """Standardized process exit codes for audit tools."""
+
+    OK = 0
+    USAGE_ERROR = 2
+    AUTH_ERROR = 10
+    VALIDATION_ERROR = 11
+    DEPENDENCY_ERROR = 12
+    COLLECTION_ERROR = 20
+    PARSE_ERROR = 21
+    OUTPUT_ERROR = 22
+    PARTIAL_SUCCESS = 30
+    UNKNOWN_ERROR = 99
+
+
+@dataclass
+class ToolError(Exception):
+    """Base exception type for standardized tool failures."""
+
+    message: str
+    exit_code: int = ExitCodes.UNKNOWN_ERROR
+    context: dict | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "type": self.__class__.__name__,
+            "message": self.message,
+            "exit_code": self.exit_code,
+            "context": self.context or {},
+        }
+
+
+class UsageError(ToolError):
+    def __init__(self, message: str, context: dict | None = None) -> None:
+        super().__init__(message=message, exit_code=ExitCodes.USAGE_ERROR, context=context)
+
+
+class AuthError(ToolError):
+    def __init__(self, message: str, context: dict | None = None) -> None:
+        super().__init__(message=message, exit_code=ExitCodes.AUTH_ERROR, context=context)
+
+
+class ValidationError(ToolError):
+    def __init__(self, message: str, context: dict | None = None) -> None:
+        super().__init__(message=message, exit_code=ExitCodes.VALIDATION_ERROR, context=context)
+
+
+class OutputError(ToolError):
+    def __init__(self, message: str, context: dict | None = None) -> None:
+        super().__init__(message=message, exit_code=ExitCodes.OUTPUT_ERROR, context=context)

--- a/shared/python/logging.py
+++ b/shared/python/logging.py
@@ -1,0 +1,32 @@
+"""Shared logging setup helpers for audit scripts."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def configure_logger(name: str, *, verbose: bool = False, quiet: bool = False) -> logging.Logger:
+    """Build a stdout/stderr aware logger with predictable behavior."""
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    logger.handlers.clear()
+    logger.propagate = False
+
+    info_level = logging.DEBUG if verbose else logging.INFO
+    warn_level = logging.CRITICAL if quiet else logging.WARNING
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(info_level)
+    stdout_handler.addFilter(lambda rec: rec.levelno < logging.WARNING)
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(warn_level)
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s - %(message)s")
+    stdout_handler.setFormatter(formatter)
+    stderr_handler.setFormatter(formatter)
+
+    logger.addHandler(stdout_handler)
+    logger.addHandler(stderr_handler)
+    return logger

--- a/shared/python/logging.py
+++ b/shared/python/logging.py
@@ -14,10 +14,11 @@ def configure_logger(name: str, *, verbose: bool = False, quiet: bool = False) -
     logger.propagate = False
 
     info_level = logging.DEBUG if verbose else logging.INFO
-    warn_level = logging.CRITICAL if quiet else logging.WARNING
+    stdout_level = logging.WARNING if quiet else info_level
+    warn_level = logging.ERROR if quiet else logging.WARNING
 
     stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setLevel(info_level)
+    stdout_handler.setLevel(stdout_level)
     stdout_handler.addFilter(lambda rec: rec.levelno < logging.WARNING)
 
     stderr_handler = logging.StreamHandler(sys.stderr)

--- a/shared/python/metadata.py
+++ b/shared/python/metadata.py
@@ -1,0 +1,22 @@
+"""Helpers to generate standardized metadata artifacts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def build_metadata(*, tool: str, run_id: str, command: str, scope: dict | None = None, record_counts: dict | None = None, warnings: list[str] | None = None, errors: list[str] | None = None) -> dict:
+    return {
+        "tool": tool,
+        "run_id": run_id,
+        "timestamp_utc": utc_now_iso(),
+        "command": command,
+        "scope": scope or {},
+        "record_counts": record_counts or {},
+        "warnings": warnings or [],
+        "errors": errors or [],
+    }

--- a/shared/python/outputs.py
+++ b/shared/python/outputs.py
@@ -1,0 +1,26 @@
+"""Shared output path and run directory helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def generate_run_id(now: datetime | None = None) -> str:
+    ts = now or datetime.now(timezone.utc)
+    return ts.strftime("%Y%m%dT%H%M%SZ")
+
+
+def ensure_run_tree(output_dir: str | Path, tool_name: str, run_id: str | None = None) -> dict[str, Path]:
+    root = Path(output_dir).expanduser().resolve() / tool_name / (run_id or generate_run_id())
+    paths = {
+        "root": root,
+        "raw": root / "raw",
+        "parsed": root / "parsed",
+        "exceptions": root / "exceptions",
+        "evidence": root / "evidence",
+        "logs": root / "logs",
+    }
+    for path in paths.values():
+        path.mkdir(parents=True, exist_ok=True)
+    return paths

--- a/shared/schemas/evidence.schema.json
+++ b/shared/schemas/evidence.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Evidence Record",
+  "type": "object",
+  "required": ["source", "collected_at", "collector", "artifact"],
+  "properties": {
+    "source": {"type": "string"},
+    "collected_at": {"type": "string", "format": "date-time"},
+    "collector": {"type": "string"},
+    "artifact": {"type": "string"},
+    "hash": {"type": "string"},
+    "notes": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/shared/schemas/exceptions.schema.json
+++ b/shared/schemas/exceptions.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Standardized Exceptions",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["type", "message", "severity"],
+    "properties": {
+      "type": {"type": "string"},
+      "message": {"type": "string"},
+      "severity": {"type": "string", "enum": ["info", "warning", "error"]},
+      "context": {"type": "object"}
+    },
+    "additionalProperties": true
+  }
+}

--- a/shared/schemas/metadata.schema.json
+++ b/shared/schemas/metadata.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Audit Tool Metadata",
+  "type": "object",
+  "required": ["tool", "run_id", "timestamp_utc", "command", "scope", "record_counts", "warnings", "errors"],
+  "properties": {
+    "tool": {"type": "string"},
+    "run_id": {"type": "string"},
+    "timestamp_utc": {"type": "string", "format": "date-time"},
+    "command": {"type": "string"},
+    "scope": {"type": "object"},
+    "record_counts": {"type": "object", "additionalProperties": {"type": "integer", "minimum": 0}},
+    "warnings": {"type": "array", "items": {"type": "string"}},
+    "errors": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": true
+}

--- a/shared/shell/common.sh
+++ b/shared/shell/common.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Shared shell helpers for standardized evidence collection scripts.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+EXIT_OK=0
+EXIT_USAGE=2
+EXIT_AUTH=10
+EXIT_VALIDATION=11
+EXIT_DEPENDENCY=12
+EXIT_COLLECTION=20
+EXIT_PARSE=21
+EXIT_OUTPUT=22
+EXIT_PARTIAL=30
+EXIT_UNKNOWN=99
+
+log_info() { printf '%s INFO %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+log_warn() { printf '%s WARN %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2; }
+log_error() { printf '%s ERROR %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2; }
+
+generate_run_id() { date -u +%Y%m%dT%H%M%SZ; }
+
+ensure_run_tree() {
+  local output_dir="$1"
+  local tool_name="$2"
+  local run_id="${3:-$(generate_run_id)}"
+  local run_root="${output_dir%/}/${tool_name}/${run_id}"
+
+  mkdir -p "${run_root}/raw" "${run_root}/parsed" "${run_root}/exceptions" "${run_root}/evidence" "${run_root}/logs"
+  printf '%s\n' "$run_root"
+}
+
+write_metadata() {
+  local metadata_file="$1"
+  local tool="$2"
+  local run_id="$3"
+  local command="$4"
+  cat > "$metadata_file" <<EOF
+{
+  "tool": "${tool}",
+  "run_id": "${run_id}",
+  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "command": "${command}"
+}
+EOF
+}

--- a/shared/shell/common.sh
+++ b/shared/shell/common.sh
@@ -37,12 +37,18 @@ write_metadata() {
   local tool="$2"
   local run_id="$3"
   local command="$4"
-  cat > "$metadata_file" <<EOF
-{
-  "tool": "${tool}",
-  "run_id": "${run_id}",
-  "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "command": "${command}"
+  python3 - "$tool" "$run_id" "$command" > "$metadata_file" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+tool, run_id, command = sys.argv[1], sys.argv[2], sys.argv[3]
+payload = {
+    "tool": tool,
+    "run_id": run_id,
+    "timestamp_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "command": command,
 }
-EOF
+print(json.dumps(payload, indent=2))
+PY
 }


### PR DESCRIPTION
### Motivation
- Provide a lightweight, reusable Phase 2 framework so future tools can inherit standard CLI, logging, metadata, output, and exception handling without changing existing script behavior.  
- Centralize deterministic output layout and evidence contracts to enforce consistent raw/parsed/exceptions/evidence/logs organization across runs.  
- Preserve the repository's shell-first, auditor-friendly approach while avoiding broad legacy migrations or adding new platform scripts in this phase.

### Description
- Added scaffolded shared directories `shared/`, `shared/python/`, `shared/shell/`, `shared/schemas/`, and `shared/examples/` with minimal, practical helpers.  
- Implemented reusable Python helpers: `shared/python/cli.py` (standard flags), `shared/python/logging.py` (stdout/stderr-aware logger), `shared/python/metadata.py` (metadata generation), `shared/python/outputs.py` (deterministic run ID and directory creation), and `shared/python/errors.py` (exception types and `ExitCodes`).  
- Added `shared/shell/common.sh` with safe shell defaults, logging helpers, `ensure_run_tree` and `write_metadata` functions, and standardized exit codes.  
- Added JSON schema contracts `shared/schemas/metadata.schema.json`, `shared/schemas/evidence.schema.json`, and `shared/schemas/exceptions.schema.json`, plus example artifacts and documentation in `shared/examples/` and `shared/README.md`, and updated `README.org` and `docs/standards-index.md` to reference the Phase 2 layer.

### Testing
- Ran repository file listing with `rg --files` to validate file presence and additions, which completed successfully.  
- Verified Python modules compiled with `python -m py_compile shared/python/*.py` and succeeded with no syntax errors.  
- Validated shell syntax with `bash -n shared/shell/common.sh` and found no syntax issues.  
- Confirmed documentation links and repository status using the `rg` grep checks and `git status --short`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f253a67a588320a5fa2e1223413078)