### PR TITLE
revert: remove Azure and Azure DevOps placeholders

### DIFF
--- a/tui/README.md
+++ b/tui/README.md
@@ -4,9 +4,9 @@ A terminal UI that walks you through running an audit. It presents a platform
 menu, collects connection details and check selection, then runs the existing
 collectors with live progress.
 
-GitHub, GitLab, and AWS are supported. Azure and Azure DevOps are stubbed in the
-menu as *coming soon*. Adding a platform is a matter of writing a runner and a
-`Platform` descriptor in `tui/platforms.py` — the screens are platform-agnostic.
+GitHub, GitLab, and AWS are supported. Adding a platform is a matter of writing
+a runner and a `Platform` descriptor in `tui/platforms.py` — the screens are
+platform-agnostic.
 
 | Pick a platform | Choose checks | Watch it run |
 |---|---|---|

--- a/tui/platforms.py
+++ b/tui/platforms.py
@@ -31,15 +31,14 @@ class Field:
 class Platform:
     key: str
     label: str
-    # The fields below drive the audit flow. A disabled ("coming soon")
-    # placeholder platform needs only key/label/enabled, so they default to
-    # empty and are never used while enabled is False.
-    subject: Callable[[dict], str] | None = None  # (settings) -> run-screen subject
-    fields: list[Field] = field(default_factory=list)
-    checks: list[Check] = field(default_factory=list)
-    default_selection: list[str] = field(default_factory=list)
-    output_dir: Callable[[dict], str] | None = None  # (settings) -> path
-    run: Callable[..., object] | None = None  # (settings, out, keys, on_event)
+    subject: Callable[
+        [dict], str
+    ]  # (settings) -> audit subject shown on the run screen
+    fields: list[Field]
+    checks: list[Check]
+    default_selection: list[str]
+    output_dir: Callable[[dict], str]  # (settings) -> path
+    run: Callable[..., object]  # (settings, output_dir, selected_keys, on_event)
     enabled: bool = True
     note: str = field(default="")
 
@@ -184,13 +183,7 @@ AWS = Platform(
     run=_aws_run,
 )
 
-# Coming soon — placeholders shown as disabled entries in the menu. Azure is the
-# cloud counterpart to AWS; Azure DevOps is the source-platform counterpart to
-# GitHub/GitLab.
-AZURE = Platform(key="azure", label="Azure", enabled=False)
-AZURE_DEVOPS = Platform(key="azure_devops", label="Azure DevOps", enabled=False)
-
-PLATFORMS = [GITHUB, GITLAB, AWS, AZURE, AZURE_DEVOPS]
+PLATFORMS = [GITHUB, GITLAB, AWS]
 
 
 def prefill(f: Field) -> str:

--- a/tui/tests/test_app.py
+++ b/tui/tests/test_app.py
@@ -165,16 +165,3 @@ def test_aws_navigation(monkeypatch):
             assert app.screen.query_one("#menu", Button).disabled is False
 
     _run(scenario())
-
-
-def test_azure_platforms_coming_soon():
-    async def scenario():
-        app = AuditApp()
-        async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
-            for key in ("azure", "azure_devops"):
-                btn = app.screen.query_one(f"#{key}", Button)
-                assert btn.disabled is True
-                assert "coming soon" in str(btn.label).lower()
-
-    _run(scenario())


### PR DESCRIPTION
## Summary

Rolls back all Azure work. Azure won't be supported — there's no practical way to create/log into an Azure account to test against, so shipping collectors that can't be verified isn't worth it.

- Reverts PR #18 (the Azure + Azure DevOps coming-soon menu placeholders and the `Platform`-field changes they needed).
- The full Azure DevOps implementation (PR #21) was closed unmerged, so nothing from it reached `main`.

After this, the TUI menu is back to **GitHub / GitLab / AWS**.

## Verification

- No `azure` references remain anywhere in the repo.
- `ruff check` clean; 31 tests pass (back to the pre-Azure suite).